### PR TITLE
Fix navbar toggle close behavior and auto-close on route/resize

### DIFF
--- a/FrontEnd/app/(WebsiteUtama)/components/LandingNavbar.tsx
+++ b/FrontEnd/app/(WebsiteUtama)/components/LandingNavbar.tsx
@@ -3,16 +3,15 @@
 import {
   Navbar,
   NavbarBrand,
-  NavbarCollapse,
-  NavbarLink,
-  NavbarToggle,
 } from "flowbite-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { FaBars, FaTimes } from "react-icons/fa";
 
 export function LandingNavbar() {
   const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const pathname = usePathname();
   const isHome = pathname === "/";
   const isAdminPage = pathname?.startsWith("/admin");
@@ -23,6 +22,21 @@ export function LandingNavbar() {
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setMenuOpen(false);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   if (isAdminPage) return null;
@@ -49,7 +63,16 @@ export function LandingNavbar() {
       </NavbarBrand>
 
       {/* TOGGLE (MOBILE) */}
-      <NavbarToggle className="md:hidden text-black focus:ring-0 ml-auto [&>span]:hidden" />
+      <button
+        type="button"
+        aria-expanded={menuOpen}
+        aria-controls="mobile-menu"
+        onClick={() => setMenuOpen((prev) => !prev)}
+        className="md:hidden text-black focus:ring-0 ml-auto p-2"
+      >
+        <span className="sr-only">Toggle menu</span>
+        {menuOpen ? <FaTimes className="h-5 w-5" /> : <FaBars className="h-5 w-5" />}
+      </button>
 
       {/* DESKTOP MENU (RIGHT ALIGNED) */}
       <div className="hidden md:flex flex-1 justify-end items-center gap-16 lg:gap-10">
@@ -80,14 +103,17 @@ export function LandingNavbar() {
       </div>
 
       {/* MOBILE MENU (COLLAPSIBLE) */}
-      <NavbarCollapse className="md:hidden">
+      <div
+        id="mobile-menu"
+        className={`md:hidden ${menuOpen ? "block" : "hidden"}`}
+      >
         <div className="flex flex-col gap-6 py-4 bg-white p-6 rounded-xl mt-4 shadow-xl">
-          <Link href="/" className="text-sm font-semibold tracking-[0.2em] text-black uppercase">Home</Link>
-          <Link href="/about" className="text-sm font-semibold tracking-[0.2em] text-black uppercase">About</Link>
-          <Link href="/project" className="text-sm font-semibold tracking-[0.2em] text-black uppercase">Project</Link>
-          <Link href="/news" className="text-sm font-semibold tracking-[0.2em] text-black uppercase">News</Link>
+          <Link href="/" onClick={() => setMenuOpen(false)} className="text-sm font-semibold tracking-[0.2em] text-black uppercase">Home</Link>
+          <Link href="/about" onClick={() => setMenuOpen(false)} className="text-sm font-semibold tracking-[0.2em] text-black uppercase">About</Link>
+          <Link href="/project" onClick={() => setMenuOpen(false)} className="text-sm font-semibold tracking-[0.2em] text-black uppercase">Project</Link>
+          <Link href="/news" onClick={() => setMenuOpen(false)} className="text-sm font-semibold tracking-[0.2em] text-black uppercase">News</Link>
         </div>
-      </NavbarCollapse>
+      </div>
     </Navbar>
   );
 }


### PR DESCRIPTION
### Motivation
- The mobile hamburger was made visible but the menu could remain open and not close on desktop after resizing or when navigating, so the navbar needed an explicit, local open/close control. 
- The Flowbite `NavbarToggle`/`NavbarCollapse` behavior was insufficient for the desired UX of closing the mobile menu on route changes and on desktop-width resizes.

### Description
- Add a local `menuOpen` state and replace `NavbarToggle` with a custom `<button>` that toggles `menuOpen` and swaps icons using `FaBars`/`FaTimes` from `react-icons`.
- Replace Flowbite `NavbarCollapse` with a controlled `<div id="mobile-menu">` that shows/hides based on `menuOpen` and wire mobile links to call `setMenuOpen(false)` when clicked.
- Auto-close the mobile menu when `pathname` changes and when the window is resized to desktop widths (`window.innerWidth >= 768`).
- Remove unused Flowbite imports (`NavbarCollapse`, `NavbarLink`, `NavbarToggle`) and keep the rest of the `Navbar`/brand layout intact in `FrontEnd/app/(WebsiteUtama)/components/LandingNavbar.tsx`.

### Testing
- Started the dev server with `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=example npm run dev` and Next compiled successfully although Google Fonts downloads failed and fell back to a local font (compile succeeded with warnings). 
- Ran a Playwright mobile script that attempted to open the page and toggle the mobile menu but the Playwright/Chromium run crashed with a SIGSEGV, so the automated UI screenshot/test did not complete (Playwright failure). 
- Verified locally in code and with resize/route hooks that `menuOpen` is reset on navigation and when resizing to desktop widths (manual code validation performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d70605c083209bb07b8735a33190)