### PR TITLE
Fix mobile navbar toggle visibility

### DIFF
--- a/FrontEnd/app/(WebsiteUtama)/components/LandingNavbar.tsx
+++ b/FrontEnd/app/(WebsiteUtama)/components/LandingNavbar.tsx
@@ -49,7 +49,7 @@ export function LandingNavbar() {
       </NavbarBrand>
 
       {/* TOGGLE (MOBILE) */}
-      <NavbarToggle className="md:hidden text-black focus:ring-0 ml-auto [&>span]:hidden" />
+      <NavbarToggle className="md:hidden text-black focus:ring-0 ml-auto" />
 
       {/* DESKTOP MENU (RIGHT ALIGNED) */}
       <div className="hidden md:flex flex-1 justify-end items-center gap-16 lg:gap-10">


### PR DESCRIPTION
### Motivation
- The mobile hamburger icon was not visible/clickable because a utility class was hiding the internal span in the Flowbite `NavbarToggle`, so the mobile menu could not be opened.

### Description
- Remove the span-hiding utility from `NavbarToggle` in `FrontEnd/app/(WebsiteUtama)/components/LandingNavbar.tsx` (replace `className="md:hidden text-black focus:ring-0 ml-auto [&>span]:hidden"` with `className="md:hidden text-black focus:ring-0 ml-auto"`).

### Testing
- Ran `npm install` in `FrontEnd` which completed successfully.
- Launched the dev server with `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=example npm run dev` and the app started successfully.
- Executed a Playwright script that opened a mobile viewport, clicked the navbar toggle and captured a screenshot showing the mobile menu; the final automated UI test succeeded and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d70605c083209bb07b8735a33190)