### PR TITLE
Add dev fallback for CHAT_SESSION_SECRET so local chat session works

### DIFF
--- a/FrontEnd/lib/chatSessionCookies.ts
+++ b/FrontEnd/lib/chatSessionCookies.ts
@@ -7,10 +7,15 @@ export const CHAT_SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
 
 const getChatSessionSecret = () => {
   const secret = process.env.CHAT_SESSION_SECRET;
-  if (!secret) {
-    throw new Error("Missing required environment variable: CHAT_SESSION_SECRET");
+  if (secret) {
+    return secret;
   }
-  return secret;
+
+  if (process.env.NODE_ENV !== "production") {
+    return "dev-only-chat-session-secret-change-me";
+  }
+
+  throw new Error("Missing required environment variable: CHAT_SESSION_SECRET");
 };
 
 export const signChatSessionId = (sessionId: string) => {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Buat file `.env.local` di dalam direktori `FrontEnd`:
 NEXT_PUBLIC_SUPABASE_URL=url_supabase_anda
 NEXT_PUBLIC_SUPABASE_ANON_KEY=key_anon_supabase_anda
 NEXT_PUBLIC_GEMINI_API_KEY=api_key_gemini_anda
+CHAT_SESSION_SECRET=rahasia-acak-untuk-menandatangani-cookie-chat
 ```
+
+> Catatan: untuk mode development lokal, jika `CHAT_SESSION_SECRET` belum diisi maka sistem akan memakai secret default khusus development. Untuk production, variabel ini **wajib** diisi.
 
 ---
 


### PR DESCRIPTION
### Motivation
- The live chat failed to initialize in local development when `CHAT_SESSION_SECRET` was not set, causing cookie signing and `/api/chat/session` to error. 
- Provide a safe developer experience while keeping strict behavior in production to avoid weakening security.

### Description
- Change `getChatSessionSecret` in `FrontEnd/lib/chatSessionCookies.ts` to return a fixed development-only secret when `CHAT_SESSION_SECRET` is not present and `NODE_ENV !== 'production'`. 
- Preserve strict behavior in production by throwing an error if `CHAT_SESSION_SECRET` is missing. 
- Add `CHAT_SESSION_SECRET` to the `FrontEnd` environment variables section in `README.md` and document the dev vs production behavior.

### Testing
- Ran `cd FrontEnd && npm run lint`, which completed successfully. 
- No additional automated tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de523f89dc83209d0a0a518c41407f)